### PR TITLE
Always callback when tests complete

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,11 @@ module.exports = function (options) {
         cb(null, file);
     }, function (cb) {
         try {
+            jasmineEnv.addReporter({
+                reportRunnerResults: function () {
+                    cb(); // all tests have finished
+                }
+            });
             jasmineEnv.execute();
         } catch (err) {
             cb(new gutil.PluginError('gulp-jasmine-node', err, { showStack: true }));


### PR DESCRIPTION
Changes to fix https://github.com/alex-pollan/gulp-jasmine-node/issues/2

The flush function callback does not get called if the tests complete successfully. In Gulp 4 this is a requirement where as in 3 you could get away with out it..
